### PR TITLE
Use fileset instead of logDir in tensorboard

### DIFF
--- a/src/assets/get-started/parallel-training/job.yaml
+++ b/src/assets/get-started/parallel-training/job.yaml
@@ -8,11 +8,8 @@ spec:
       limits:
         cpu: 1
         memory: 1Gi
-    logDir:
-      pvc:
-      - name: mnist
-        subpath: 
-        - ./log                  # 日志文件路径
+    trainingLogFilesets:
+      - t9k://pvc/mnist/log      # 日志文件路径
     image: tensorflow/tensorflow:2.14.0
                                  # TensorBoard 服务器使用的镜像
   torchrunConfig:


### PR DESCRIPTION
此时前端还没有添加 logDir，在示例中依然使用 Fileset

同时 `pvc.subpath` 应该是 `pvc.subPath`