### PR TITLE
minor fix

### DIFF
--- a/src/tools/cli-t9k-pf/guide.md
+++ b/src/tools/cli-t9k-pf/guide.md
@@ -20,7 +20,7 @@ arch=amd64
 
 ``` bash
 tar -zxvf "$HOME/Downloads/t9k-pf-$version-$os-$arch.tar.gz"
-mv t9k-pf-$os-$arch /usr/local/bin/t9k-pf
+mv t9k-pf /usr/local/bin/t9k-pf
 rm -f "$HOME/Downloads/t9k-pf-$version-$os-$arch.tar.gz"
 ```
 

--- a/src/tools/cli-t9k/guide.md
+++ b/src/tools/cli-t9k/guide.md
@@ -20,7 +20,7 @@ arch=amd64
 
 ``` bash
 tar -zxvf "$HOME/Downloads/t9k-$version-$os-$arch.tar.gz"
-mv t9k-$os-$arch /usr/local/bin/t9k
+mv t9k /usr/local/bin/t9k
 rm -f "$HOME/Downloads/t9k-$version-$os-$arch.tar.gz"
 ```
 


### PR DESCRIPTION
t9k 的命令行工具发布过程有过修改，现在解压后的文件名不再包含 “-$os-$arch” 的部分。